### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ So if you want to require bower_component in boot.js file you neeed to set path 
 require('../bower_components/module/module-script');
 ```
 
-And you can not set paths to CodeMirror modes at requirejs.config becasue:
+And you can not set paths to CodeMirror modes at requirejs.config because:
 
 CodeMirror check if requriejs is used, and if so - CodeMirror will use it. And If you descrive path to CodeMirror's mode at requriejs.config -
 **require** function inside modes scitpts will have relative path from **boot.js** and it will be able to load other dependencies because paths will be wrong.


### PR DESCRIPTION
@tuchk4, I've corrected a typographical error in the documentation of the [requirejs-codemirror](https://github.com/tuchk4/requirejs-codemirror) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
